### PR TITLE
fix: process.env typecheck

### DIFF
--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -34,8 +34,6 @@ export async function createCluster(
   const baseImage = params['minikube.cluster.creation.base-image'];
   const mountString = params['minikube.cluster.creation.mount-string'];
 
-  const env = { ...process.env };
-
   const startArgs = ['start', '--profile', clusterName, '--driver', driver, '--container-runtime', runtime];
 
   // add base image parameter
@@ -48,10 +46,10 @@ export async function createCluster(
     startArgs.push('--mount-string', mountString);
   }
 
-  // update PATH to include minikube
-  env.PATH = getMinikubePath();
-
-  env.MINIKUBE_HOME = getMinikubeHome();
+  const env: Record<string, string> = {
+    PATH: getMinikubePath(),
+    MINIKUBE_HOME: getMinikubeHome() ?? '',
+  };
 
   // now execute the command to create the cluster
   try {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -121,9 +121,11 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
       const lifecycle: extensionApi.ProviderConnectionLifecycle = {
         start: async (): Promise<void> => {
           try {
-            const env = { ...process.env };
-            env.PATH = getMinikubePath();
-            await extensionApi.process.exec(minikubeCli, ['start', '--profile', cluster.name], { env });
+            await extensionApi.process.exec(minikubeCli, ['start', '--profile', cluster.name], {
+              env: {
+                PATH: getMinikubePath(),
+              },
+            });
           } catch (err) {
             console.error(err);
             // propagate the error
@@ -131,17 +133,20 @@ async function updateClusters(provider: extensionApi.Provider, containers: exten
           }
         },
         stop: async (): Promise<void> => {
-          const env = { ...process.env };
-          env.PATH = getMinikubePath();
           await extensionApi.process.exec(minikubeCli, ['stop', '--profile', cluster.name, '--keep-context-active'], {
-            env,
+            env: {
+              PATH: getMinikubePath(),
+            },
           });
         },
         delete: async (logger): Promise<void> => {
-          const env = { ...process.env };
-          env.PATH = getMinikubePath();
-          env.MINIKUBE_HOME = getMinikubeHome();
-          await extensionApi.process.exec(minikubeCli, ['delete', '--profile', cluster.name], { env, logger });
+          await extensionApi.process.exec(minikubeCli, ['delete', '--profile', cluster.name], {
+            env: {
+              PATH: getMinikubePath(),
+              MINIKUBE_HOME: getMinikubeHome() ?? '',
+            },
+            logger,
+          });
         },
       };
       // create a new connection

--- a/src/image-handler.ts
+++ b/src/image-handler.ts
@@ -57,15 +57,17 @@ export class ImageHandler {
     if (selectedCluster) {
       let name = image.name;
       let filename: string;
-      const env = { ...process.env };
 
       // Create a name:tag string for the image
       if (image.tag) {
         name = name + ':' + image.tag;
       }
 
-      env.PATH = getMinikubePath();
-      env.MINIKUBE_HOME = getMinikubeHome();
+      const env: Record<string, string> = {
+        PATH: getMinikubePath(),
+        MINIKUBE_HOME: getMinikubeHome() ?? '',
+      };
+
       try {
         // Create a temporary file to store the image
         filename = await tmpName();

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,7 @@ export function getMinikubePath(): string {
       return env.PATH.concat(':').concat(macosExtraPath);
     }
   } else {
-    return env.PATH;
+    return env.PATH ?? '';
   }
 }
 


### PR DESCRIPTION
Split up of https://github.com/podman-desktop/extension-minikube/pull/223.

## Related issues

Part of https://github.com/podman-desktop/extension-minikube/issues/154

## `process.env` type issue

This PR remove the `process.env` from the envs passed to the exec api because its type is incompatible with the API, and is unessessary.

When running `tsc` we see the following error

```
src/create-cluster.ts:58:53 - error TS2322: Type '{ [x: string]: string | undefined; TZ?: string; }' is not assignable to type '{ [key: string]: string; }'.
  'string' index signatures are incompatible.
    Type 'string | undefined' is not assignable to type 'string'.
      Type 'undefined' is not assignable to type 'string'.

58     await processApi.exec(minikubeCli, startArgs, { env, logger, token });
```

### Incompatible type

process.env is incompatible with our RunOptions#env. 

`process.env` is typed as `ProcessEnv`, which is the following 
```ts
interface ProcessEnv extends Dict<string> {
                /**
                 * Can be used to change the default timezone at runtime
                 */
                TZ?: string;
            }
```

This is not compatible with our `RunOptions#env` defined as

```ts
export interface RunOptions {
    env?: { [key: string]: string };
...
```

### Unnecessary 

If only the type was incompatible I would have forced the typecheck by casting it, or using some Object.assign magic, but this is not necessary as podman desktop core is already doing it for us.

Podman desktop automatically adds it see [main/src/plugin/util/exec.ts#L50](https://github.com/podman-desktop/podman-desktop/blob/1e432899a5f8321917c615e7c15de32a39de94a0/packages/main/src/plugin/util/exec.ts#L50)
