### PR TITLE
fix: missing minikube home in version check

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -365,7 +365,11 @@ describe('getMinikubeVersion', () => {
       await getMinikubeVersion('/dummy/minikube');
     }).rejects.toThrowError('something wrong');
 
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('/dummy/minikube', ['version', '--short'], expect.anything());
+    expect(extensionApi.process.exec).toHaveBeenCalledWith(
+      '/dummy/minikube',
+      ['version', '--short'],
+      expect.anything(),
+    );
   });
 
   test('should format the version output', async () => {

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -365,7 +365,7 @@ describe('getMinikubeVersion', () => {
       await getMinikubeVersion('/dummy/minikube');
     }).rejects.toThrowError('something wrong');
 
-    expect(extensionApi.process.exec).toHaveBeenCalledWith('/dummy/minikube', ['version', '--short']);
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('/dummy/minikube', ['version', '--short'], expect.anything());
   });
 
   test('should format the version output', async () => {
@@ -377,6 +377,27 @@ describe('getMinikubeVersion', () => {
 
     const result = await getMinikubeVersion('/dummy/minikube');
     expect(result).toBe('1.5.3');
+  });
+
+  test('should use the additional envs', async () => {
+    const existingEnvHome = '/my-existing-minikube-home';
+    const existingConfigHome = '';
+    process.env.MINIKUBE_HOME = existingEnvHome;
+
+    configGetMock.mockReturnValue(existingConfigHome);
+
+    vi.mocked(extensionApi.process.exec).mockResolvedValue({
+      stdout: 'v1.5.3',
+      stderr: '',
+      command: '',
+    });
+
+    await getMinikubeVersion('/dummy/minikube');
+    expect(extensionApi.process.exec).toHaveBeenCalledWith('/dummy/minikube', ['version', '--short'], {
+      env: expect.objectContaining({
+        MINIKUBE_HOME: existingEnvHome,
+      }),
+    });
   });
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -119,7 +119,9 @@ export async function installBinaryToSystem(binaryPath: string, binaryName: stri
 }
 
 export async function getMinikubeVersion(executable: string): Promise<string> {
-  const result = await extensionApi.process.exec(executable, ['version', '--short']);
+  const result = await extensionApi.process.exec(executable, ['version', '--short'], {
+    env: getMinikubeAdditionalEnvs(),
+  });
   return result.stdout.replace('v', '').trim();
 }
 


### PR DESCRIPTION
## Description

Add the missing additional envs to the minikube cli version check. 

## Related issue

Fixes https://github.com/podman-desktop/extension-minikube/issues/242

## Tests

- [x] unit tests has been provided