### PR TITLE
Add KUBECONFIG env into minikube calls

### DIFF
--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -27,6 +27,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import {
   deleteFile,
   deleteFileAsAdmin,
+  getKubeConfig,
   getMinikubeAdditionalEnvs,
   getMinikubeHome,
   getMinikubePath,
@@ -136,6 +137,34 @@ describe('getMinikubeHome', () => {
 
     expect(computedHome).not.toEqual(existingEnvHome);
     expect(computedHome).toEqual(existingConfigHome);
+  });
+});
+
+describe('getKubeConfig', () => {
+  test('getKubeConfig with empty configuration property', async () => {
+    const existingEnvKubeConfig = '/my-existing-kube-config-file';
+    const existingConfigKubeConfig = '';
+    process.env.KUBECONFIG = existingEnvKubeConfig;
+
+    configGetMock.mockReturnValue(existingConfigKubeConfig);
+
+    const computedKubeConfig = getKubeConfig();
+
+    expect(computedKubeConfig).toEqual(existingEnvKubeConfig);
+    expect(computedKubeConfig).not.toEqual(existingConfigKubeConfig);
+  });
+
+  test('getKubeConfig with empty configuration property', async () => {
+    const existingEnvKubeConfig = '/my-existing-kube-config-file';
+    const existingConfigKubeConfig = '/my-another-existing-kube-config-file';
+    process.env.KUBECONFIG = existingEnvKubeConfig;
+
+    configGetMock.mockReturnValue(existingConfigKubeConfig);
+
+    const computedKubeConfig = getKubeConfig();
+
+    expect(computedKubeConfig).not.toEqual(existingEnvKubeConfig);
+    expect(computedKubeConfig).toEqual(existingConfigKubeConfig);
   });
 });
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -45,6 +45,10 @@ export function getMinikubeAdditionalEnvs(): Record<string, string> {
   if (minikubeHome) {
     env['MINIKUBE_HOME'] = minikubeHome;
   }
+  const kubeconfig = getKubeConfig();
+  if (kubeconfig) {
+    env['KUBECONFIG'] = kubeconfig;
+  }
   return env;
 }
 
@@ -57,6 +61,18 @@ export function getMinikubeHome(): string | undefined {
     return env.MINIKUBE_HOME;
   } else {
     return minikubeHome;
+  }
+}
+
+export function getKubeConfig(): string | undefined {
+  const kubernetesConfiguration = extensionApi.configuration.getConfiguration('kubernetes');
+  const kubeConfig = kubernetesConfiguration.get<string>('Kubeconfig');
+  // Check env if configuration is not applied in UI
+  if (!kubeConfig) {
+    const env = process.env;
+    return env.KUBECONFIG;
+  } else {
+    return kubeConfig;
   }
 }
 


### PR DESCRIPTION
Based on [this](https://github.com/podman-desktop/extension-minikube/issues/215#issuecomment-2488795392) and [this](https://github.com/podman-desktop/extension-minikube/issues/215#issuecomment-2489527077)

Minikube, by design, uses `KUBECONFIG` env variable to write it's cluster configuration.
Due to keeping consistency between tools around `kubectl` and `minikube` (e.g., start cluster via Podman UI and manage via cli), Podman Desktop Minikube extension should also use `KUBECONFIG` if defined for any `minikube` binary calls to avoid error E1120:

```
E1120 17:53:32.745267   45820 status.go:417] kubeconfig endpoint: get endpoint: "minikube" does not appear in $KUBECONFIG
```