### PR TITLE
feat: add addons for minikube cluster creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "minikube.cluster.creation.addons": {
           "type": "string",
           "scope": "KubernetesProviderConnectionFactory",
-          "markdownDescription": "Comma-separated list of addons to enable. See `minikube addons list` for a list of valid addon names"
+          "markdownDescription": "Comma-separated list of [addons](https://minikube.sigs.k8s.io/docs/commands/addons/) to enable. See `minikube addons list` for a list of valid addon names"
         },
         "minikube.cluster.creation.base-image": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
           "scope": "KubernetesProviderConnectionFactory",
           "description": "The total number of nodes to spin up"
         },
+        "minikube.cluster.creation.addons": {
+          "type": "string",
+          "scope": "KubernetesProviderConnectionFactory",
+          "markdownDescription": "Comma-separated list of addons to enable. See `minikube addons list` for a list of valid addon names"
+        },
         "minikube.cluster.creation.base-image": {
           "type": "string",
           "scope": "KubernetesProviderConnectionFactory",

--- a/src/create-cluster.ts
+++ b/src/create-cluster.ts
@@ -34,6 +34,7 @@ export async function createCluster(
   const nodes = params['minikube.cluster.creation.nodes'];
   const baseImage = params['minikube.cluster.creation.base-image'];
   const mountString = params['minikube.cluster.creation.mount-string'];
+  const addons = params['minikube.cluster.creation.addons'];
 
   const startArgs = ['start', '--profile', clusterName, '--driver', driver, '--container-runtime', runtime];
 
@@ -48,6 +49,10 @@ export async function createCluster(
   }
   if (nodes) {
     startArgs.push('--nodes', nodes);
+  }
+  if (addons) {
+    startArgs.push('--install-addons');
+    startArgs.push('--addons', addons);
   }
 
   // now execute the command to create the cluster


### PR DESCRIPTION
Resolves https://github.com/podman-desktop/extension-minikube/issues/36

Just passing `--install-addons` and `--addons` if defined during cluster creation

<img width="655" alt="addons" src="https://github.com/user-attachments/assets/718c67fd-00a4-44d1-8781-3afcc6f3a4ff">

P.S. i think cluster creation UI become to look heavier, but it's just an IMHO