### PR TITLE
chore(ci):  improve windows e2e tests workflow

### DIFF
--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -165,6 +165,14 @@ jobs:
         # Check logs for the x session
         podman logs x-session
 
+    - name: Ensure getting current HEAD version of the test framework
+      working-directory: ./extension-minikube
+      run: |
+        # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
+        version=$(npm view @podman-desktop/tests-playwright@next version)
+        echo "Version of @podman-desktop/tests-playwright to be used: $version"
+        jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
+
     - name: Download Podman, do not initialize
       run: |
         podman run --rm -d --name pde2e-podman-run \

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Podman Desktop Minikube E2E
+name: e2e-main-windows
 
 on:
   push:
@@ -75,7 +75,7 @@ jobs:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     env:
-      MAPT_VERSION: v0.7.2
+      MAPT_VERSION: v0.7.3
       MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
@@ -138,7 +138,7 @@ jobs:
             --nested-virt \
             --cpus 8 \
             --memory 16 \
-            --tags project=podman-desktop \
+            --tags project=podman-desktop,source=github,org=${{github.repository_owner}},run=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
             --spot
         # Check logs 
         podman logs -f windows-create

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -103,7 +103,7 @@ jobs:
         DEFAULT_NPM_TARGET: 'test:e2e'
         DEFAULT_ENV_VARS: 'TEST_PODMAN_MACHINE=false'
         DEFAULT_PODMAN_OPTIONS: 'INIT=1,START=1,ROOTFUL=1,NETWORKING=0'
-        DEFAULT_EXT_REPO_OPTIONS: 'REPO=extensio-minikube,FORK=podman-desktop,BRANCH=main'
+        DEFAULT_EXT_REPO_OPTIONS: 'REPO=extension-minikube,FORK=podman-desktop,BRANCH=main'
         DEFAULT_VERSION: "${{ env.PD_PODMAN_VERSION || '5.3.1' }}"
         DEFAULT_URL: "https://github.com/containers/podman/releases/download/v$DEFAULT_VERSION/podman-remote-release-windows_amd64.zip"
       run: |
@@ -164,14 +164,6 @@ jobs:
         podman wait --condition running x-session
         # Check logs for the x session
         podman logs x-session
-
-    - name: Ensure getting current HEAD version of the test framework
-      working-directory: ./extension-minikube
-      run: |
-        # workaround for https://github.com/containers/podman-desktop-extension-bootc/issues/712
-        version=$(npm view @podman-desktop/tests-playwright@next version)
-        echo "Version of @podman-desktop/tests-playwright to be used: $version"
-        jq --arg version "$version" '.devDependencies."@podman-desktop/tests-playwright" = $version' package.json > package.json_tmp && mv package.json_tmp package.json
 
     - name: Download Podman, do not initialize
       run: |


### PR DESCRIPTION
What does this PR do?
Changes the name of the workflow, updates the mapt image version, extends the tags parameter to link the machine to the GitHub Actions execution.

UPD: ensures getting current HEAD version of the test framework