### PR TITLE
chore: fix minikube workflow

### DIFF
--- a/.github/workflows/e2e-main.yaml
+++ b/.github/workflows/e2e-main.yaml
@@ -125,7 +125,7 @@ jobs:
         working-directory: ./extension-minikube
         env:
           PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
-          MINIKUBE_DRIVER_GHA: ${{ MINIKUBE_DRIVER }}        
+          MINIKUBE_DRIVER_GHA: ${{ env.MINIKUBE_DRIVER }}        
         run: pnpm test:e2e
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
What does this PR do?
 fixes an issue where MINIKUBE_DRIVER was not recognized by correctly referencing it as env.MINIKUBE_DRIVER in the workflow