### PR TITLE
chore(test):  Remove the Minikube cluster and all traces before closing the application

### DIFF
--- a/tests/playwright/src/spec/minikube-extension.spec.ts
+++ b/tests/playwright/src/spec/minikube-extension.spec.ts
@@ -51,7 +51,6 @@ let minikubeResourceCard: ResourceConnectionCardPage;
 const skipExtensionInstallation = process.env.SKIP_EXTENSION_INSTALL === 'true';
 const driverGHA = process.env.MINIKUBE_DRIVER_GHA ?? '';
 
-
 test.beforeAll(async ({ runner, page, welcomePage }) => {
     runner.setVideoAndTraceName('minikube-extension-e2e');
     await welcomePage.handleWelcomePage(true);
@@ -71,7 +70,7 @@ test.use({
 test.afterAll(async ({ runner }) => {
     if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux'){
       console.log('Removing Minikube cluster traces');
-      execSync('/usr/bin/minikube delete', { stdio: 'inherit' });
+      execSync(`minikube delete`, { stdio: 'inherit' });
     }
 
     await runner.close();   

--- a/tests/playwright/src/spec/minikube-extension.spec.ts
+++ b/tests/playwright/src/spec/minikube-extension.spec.ts
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  ***********************************************************************/
 
+import { execSync } from 'node:child_process';
+
 import { 
     checkClusterResources,
     deleteCluster,
@@ -67,6 +69,11 @@ test.use({
   });
 
 test.afterAll(async ({ runner }) => {
+    if (process.env.GITHUB_ACTIONS && process.env.RUNNER_OS === 'Linux'){
+      console.log('Removing Minikube cluster traces');
+      execSync('/usr/bin/minikube delete', { stdio: 'inherit' });
+    }
+
     await runner.close();   
 });
 


### PR DESCRIPTION
What does this pr do?
Removes the Minikube cluster and all traces before closing the application

issue: https://github.com/podman-desktop/extension-minikube/issues/397