### PR TITLE
fix: fix windows workflow

### DIFF
--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -80,7 +80,7 @@ jobs:
     name: windows-${{ matrix.windows-version }}-${{ matrix.windows-featurepack }}
     runs-on: ubuntu-latest
     env:
-      MAPT_VERSION: v0.8.0
+      MAPT_VERSION: v0.8.2
       MAPT_IMAGE: quay.io/redhat-developer/mapt
     strategy:
       fail-fast: false
@@ -150,7 +150,7 @@ jobs:
             --tags project=podman-desktop,source=github,org=${{github.repository_owner}},run=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }} \
             --spot \
             # Workaround for https://github.com/redhat-developer/mapt/issues/451
-            --spot-excluded-regions southafricawest,australiacentral2,switzerlandwest
+            --spot-excluded-regions "southafricawest,australiacentral2,switzerlandwest"
         # Check logs 
         podman logs -f windows-create
 


### PR DESCRIPTION
**What does the PR do?**

Fixes the spot-excluded-regions parameter.
Updates the mapt image version.