### PR TITLE
test: new Kubernetes e2e tests setup with Minikube

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2024-2025 Red Hat, Inc.
+# Copyright (C) 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: e2e-main
+name: kubernetes-e2e-tests
 
 on:
   push:
@@ -50,13 +50,9 @@ on:
         - docker
         - podman 
         required: true
-      npm_target:
-        default: 'test:e2e'
-        description: 'The npm target to run tests. Use "test:e2e:all" to run all test suites, including Kubernetes tests.'
-        type: string 
 
 jobs:
-  e2e-tests:
+  kubernetes-e2e-tests:
     name: Run E2E tests
     runs-on: ubuntu-24.04
     steps:
@@ -80,7 +76,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm
@@ -92,12 +88,31 @@ jobs:
         env:
           DEFAULT_EXTENSION_IMAGE: 'ghcr.io/podman-desktop/podman-desktop-extension-minikube:nightly'
           DEFAULT_MINIKUBE_DRIVER: 'docker'
-          DEFAULT_NPM_TARGET: 'test:e2e'
         run: |
           echo "EXTENSION_IMAGE=${{ github.event.inputs.extension_image || env.DEFAULT_EXTENSION_IMAGE }}" >> $GITHUB_ENV
           echo "MINIKUBE_DRIVER=${{ github.event.inputs.minikube_driver || env.DEFAULT_MINIKUBE_DRIVER }}" >> $GITHUB_ENV
-          echo "NPM_TARGET"=${{ github.event.inputs.npm_target || env.DEFAULT_NPM_TARGET }}" >> $GITHUB_ENV
-
+      
+      - name: Update podman
+        run: |
+          echo "ubuntu version from kubic repository to install podman we need (v5)"
+          ubuntu_version='23.10'
+          echo "Add unstable kubic repo into list of available sources and get the repo key"
+          sudo sh -c "echo 'deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list"
+          curl -L "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add -
+          echo "install necessary dependencies for criu package which is not part of ${ubuntu_version}"
+          sudo apt-get install -qq libprotobuf32t64 python3-protobuf libnet1
+          echo "install criu manually from static location"
+          curl -sLO http://cz.archive.ubuntu.com/ubuntu/pool/universe/c/criu/criu_3.16.1-2_amd64.deb && sudo dpkg -i criu_3.16.1-2_amd64.deb
+          echo "Updating all dependencies..."
+          sudo apt-get update -qq
+          echo "installing/update podman package..."
+          sudo apt-get -qq -y install podman || { echo "Start fallback steps for podman nightly installation from a static mirror" && \
+            sudo sh -c "echo 'deb http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list" && \
+            curl -L "http://ftp.lysator.liu.se/pub/opensuse/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key" | sudo apt-key add - && \
+            sudo apt-get update && \
+            sudo apt-get -y install podman; }
+          podman version
+          
       - name: Revert unprivileged user namespace restrictions in Ubuntu 24.04
         run: |
           # allow unprivileged user namespace
@@ -148,7 +163,7 @@ jobs:
           PODMAN_DESKTOP_ARGS: ${{ github.workspace }}/podman-desktop
           EXTENSION_IMAGE: ${{ env.EXTENSION_IMAGE }}
           MINIKUBE_DRIVER_GHA: ${{ env.MINIKUBE_DRIVER }}        
-        run: pnpm ${{ env.NPM_TARGET }}
+        run: pnpm test:e2e:k8s
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v5

--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Build Podman Desktop for E2E tests
         working-directory: ./podman-desktop
-        run: pnpm build
+        run: test:e2e:build
       
       - name: Ensure getting current HEAD version of the test framework
         working-directory: ./extension-minikube

--- a/.github/workflows/e2e-windows.yaml
+++ b/.github/workflows/e2e-windows.yaml
@@ -46,7 +46,7 @@ on:
         required: true
       npm_target:
         default: 'test:e2e'
-        description: 'npm target to run tests'
+        description: 'The npm target to run tests. Use "test:e2e:all" to run all test suites, including Kubernetes tests.'
         type: string
         required: true
       podman_remote_url:

--- a/package.json
+++ b/package.json
@@ -89,7 +89,9 @@
     "lint:fix": "eslint . --fix",
     "watch": "vite build -w",
     "typecheck": "tsc --noEmit",
-    "test:e2e": "cd tests/playwright && npm run test:e2e"
+    "test:e2e": "cd tests/playwright && npm run test:e2e",
+    "test:e2e:k8s": "cd tests/playwright && npm run test:e2e:k8s",
+    "test:e2e:all": "cd tests/playwright && npm run test:e2e:all"
   },
   "dependencies": {
     "@octokit/rest": "^21.1.1",

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -5,7 +5,9 @@
     "type": "module",
     "scripts": {
       "test:e2e:setup": "xvfb-maybe --auto-servernum --server-args='-screen 0 1280x960x24' --",
-      "test:e2e": "npm run test:e2e:setup npx playwright test src/spec/"
+      "test:e2e": "npm run test:e2e:setup -- npx playwright test src/spec/ --grep-invert @k8s_e2e",
+      "test:e2e:k8s": "npm run test:e2e:setup -- npx playwright test src/spec/ -g @k8s_e2e", 
+      "test:e2e:all": "npm run test:e2e:setup -- npx playwright test src/spec/"
     },
     "author": "Red Hat",
     "license": "Apache-2.0",

--- a/tests/playwright/src/spec/kubernetes.spec.ts
+++ b/tests/playwright/src/spec/kubernetes.spec.ts
@@ -1,0 +1,73 @@
+/**********************************************************************
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ***********************************************************************/
+
+import { checkKubernetesResourceState, deleteCluster, ensureCliInstalled, expect as playExpect, isLinux, KubernetesResources, KubernetesResourceState, minikubeExtension,test} from '@podman-desktop/tests-playwright';
+
+import { createMinikubeCluster} from '../utility/operations';
+
+const CLUSTER_NAME: string = 'minikube';
+const MINIKUBE_NODE: string = CLUSTER_NAME;
+const RESOURCE_NAME: string = 'minikube';
+const CLUSTER_CREATION_TIMEOUT: number = 300_000;
+
+const EXTENSION_IMAGE: string = process.env.EXTENSION_IMAGE ?? 'ghcr.io/podman-desktop/podman-desktop-extension-minikube:nightly';
+
+const driverGha: string = process.env.MINIKUBE_DRIVER_GHA ?? '';
+const useGhaDriver: boolean = !!process.env.GITHUB_ACTIONS && isLinux;
+
+test.beforeAll(async ({ runner, welcomePage, page, navigationBar }) => {
+  test.setTimeout(CLUSTER_CREATION_TIMEOUT);
+  runner.setVideoAndTraceName('minikube-kubernetes-e2e');
+  await welcomePage.handleWelcomePage(true);
+
+  // Install minikube extension
+  const extensionsPage = await navigationBar.openExtensions();
+  await playExpect(extensionsPage.header).toBeVisible();
+  await playExpect.poll(async () => extensionsPage.extensionIsInstalled(minikubeExtension.extensionFullLabel)).toBeFalsy();
+  await extensionsPage.openCatalogTab();
+  await extensionsPage.installExtensionFromOCIImage(EXTENSION_IMAGE);
+
+  const settingsBar = await navigationBar.openSettings();
+  await settingsBar.cliToolsTab.click();
+  await ensureCliInstalled(page, 'Minikube');
+
+  if (useGhaDriver) {
+    await createMinikubeCluster(page, CLUSTER_NAME, false, CLUSTER_CREATION_TIMEOUT, {driver: driverGha});
+  } else {
+    await createMinikubeCluster(page, CLUSTER_NAME, true, CLUSTER_CREATION_TIMEOUT);
+  }
+});
+
+test.afterAll(async ({ navigationBar, runner, page }) => {
+  try {
+    await deleteCluster(page, RESOURCE_NAME, MINIKUBE_NODE, CLUSTER_NAME);
+    //Delete minikube extension
+    const extensionsPage = await navigationBar.openExtensions();
+    await playExpect(extensionsPage.header).toBeVisible();
+    const minikubeExtensionCard = await extensionsPage.getInstalledExtension(minikubeExtension.extensionName, minikubeExtension.extensionFullLabel);
+    await minikubeExtensionCard.removeExtension();
+  } finally {
+    await runner.close();
+  }
+});
+
+test.describe.serial('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }, () => {
+  test('Kubernetes Nodes test', async ({ page }) => {
+    await checkKubernetesResourceState(page, KubernetesResources.Nodes, MINIKUBE_NODE, KubernetesResourceState.Running);
+  });
+});


### PR DESCRIPTION
## What does this PR do?  
This PR introduces a new Kubernetes test scenario, enabling Kubernetes e2e tests to run using a Minikube cluster.  

This PR  must be merged after https://github.com/podman-desktop/extension-minikube/pull/514.  

## Related Issue  
Closes [#471](https://github.com/podman-desktop/extension-minikube/issues/471).  

## Testing  
Successfully tested on my fork: [GitHub Actions Run](https://github.com/amisskii/podman-desktop-extension-minikube/actions/runs/14219462771).  


