### PR TITLE
chore(test): k8s deployment resource e2e test

### DIFF
--- a/.github/workflows/e2e-kubernetes-main.yaml
+++ b/.github/workflows/e2e-kubernetes-main.yaml
@@ -65,6 +65,7 @@ jobs:
           path: ${{ github.event.inputs.repositoryName }}
 
       - uses: actions/checkout@v4
+        if: github.event_name == 'push'
         with: 
           path: extension-minikube
 

--- a/tests/playwright/resources/kubernetes/test-deployment-resource.yaml
+++ b/tests/playwright/resources/kubernetes/test-deployment-resource.yaml
@@ -1,0 +1,40 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment-resource
+  labels:
+    app: test-deployment-resource
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test-deployment-resource
+  template:
+    metadata:
+      labels:
+        app: test-deployment-resource
+    spec:
+      containers:
+      - name: test-deployment-resource
+        image: ghcr.io/podmandesktop-ci/nginx
+        ports:
+        - containerPort: 80
+ 


### PR DESCRIPTION
What does this pr do? 
Adds a new e2e test for a Kubernetes deployment resource using a Minikube cluster. The test also covers editing the deployment using the Kubernetes edit feature.

Issues: 
https://github.com/podman-desktop/extension-minikube/issues/468
https://github.com/podman-desktop/extension-minikube/issues/476