### PR TITLE
chore(test): e2e tests for configmaps, secrets and pvc k8s resources

### DIFF
--- a/tests/playwright/resources/kubernetes/test-configmap-resource.yaml
+++ b/tests/playwright/resources/kubernetes/test-configmap-resource.yaml
@@ -1,0 +1,25 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap-resource
+data:
+  configmap-username: test-configmap
+ 

--- a/tests/playwright/resources/kubernetes/test-pod-configmaps-secrets.yaml
+++ b/tests/playwright/resources/kubernetes/test-pod-configmaps-secrets.yaml
@@ -1,0 +1,33 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-configmaps-secrets
+spec:
+  containers:
+    - name: test-app-configmap-secret
+      image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+      envFrom:
+        - configMapRef:
+            name: test-configmap-resource
+        - secretRef: 
+            name: test-secret-resource
+ 

--- a/tests/playwright/resources/kubernetes/test-pod-pvcs.yaml
+++ b/tests/playwright/resources/kubernetes/test-pod-pvcs.yaml
@@ -1,0 +1,35 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-pvcs
+spec:
+  containers:
+  - name: test-app-pvc
+    image: quay.io/podman-desktop-demo/podify-demo-backend:v1
+    volumeMounts:
+    - name: config-volume
+      mountPath: /etc/config
+  volumes:
+  - name: config-volume
+    persistentVolumeClaim:
+      claimName: test-pvc-resource
+ 

--- a/tests/playwright/resources/kubernetes/test-pvc-resource.yaml
+++ b/tests/playwright/resources/kubernetes/test-pvc-resource.yaml
@@ -1,0 +1,31 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-pvc-resource
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: standard
+ 

--- a/tests/playwright/resources/kubernetes/test-secret-resource.yaml
+++ b/tests/playwright/resources/kubernetes/test-secret-resource.yaml
@@ -1,0 +1,27 @@
+# /**********************************************************************
+#  * Copyright (C) 2025 Red Hat, Inc.
+#  *
+#  * Licensed under the Apache License, Version 2.0 (the "License");
+#  * you may not use this file except in compliance with the License.
+#  * You may obtain a copy of the License at
+#  *
+#  * http://www.apache.org/licenses/LICENSE-2.0
+#  *
+#  * Unless required by applicable law or agreed to in writing, software
+#  * distributed under the License is distributed on an "AS IS" BASIS,
+#  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  * See the License for the specific language governing permissions and
+#  * limitations under the License.
+#  *
+#  * SPDX-License-Identifier: Apache-2.0
+#  ***********************************************************************/
+
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret-resource
+type: Opaque
+stringData:
+  secret-username: "test-secret"
+ 

--- a/tests/playwright/src/spec/kubernetes.spec.ts
+++ b/tests/playwright/src/spec/kubernetes.spec.ts
@@ -19,7 +19,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { checkDeploymentReplicasInfo, checkKubernetesResourceState, createKubernetesResource, deleteCluster, deleteKubernetesResource, editDeploymentYamlFile, ensureCliInstalled, expect as playExpect, isLinux, KubernetesResources, KubernetesResourceState, minikubeExtension,PlayYamlRuntime,test, applyYamlFileToCluster, deletePod} from '@podman-desktop/tests-playwright';
+import { applyYamlFileToCluster, checkDeploymentReplicasInfo, checkKubernetesResourceState, createKubernetesResource, deleteCluster, deleteKubernetesResource, deletePod,editDeploymentYamlFile, ensureCliInstalled, expect as playExpect, isLinux, KubernetesResources, KubernetesResourceState, minikubeExtension,PlayYamlRuntime,test} from '@podman-desktop/tests-playwright';
 
 import { createMinikubeCluster} from '../utility/operations';
 

--- a/tests/playwright/src/spec/kubernetes.spec.ts
+++ b/tests/playwright/src/spec/kubernetes.spec.ts
@@ -137,12 +137,18 @@ test.describe.serial('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }
   });
   test.describe
   .serial('PVC lifecycle test', () => {
-    test('Create a new PVC resource', async ({ page }) => {
-      await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH, KUBERNETES_RUNTIME);
-      await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Stopped);
-    });
-    test('Bind the PVC to a pod', async ({ page }) => {
+    test('CCreate a pod bound to a PVC and verify its stopped', async({page}) => {
       await applyYamlFileToCluster(page, PVC_POD_YAML_PATH, KUBERNETES_RUNTIME);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Pods,
+        PVC_POD_NAME,
+        KubernetesResourceState.Stopped,
+      );
+    }) 
+    test('Create a PVC and verify the bound pod is in running state', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH, KUBERNETES_RUNTIME);
+      await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Running);
       await checkKubernetesResourceState(
         page,
         KubernetesResources.Pods,

--- a/tests/playwright/src/spec/kubernetes.spec.ts
+++ b/tests/playwright/src/spec/kubernetes.spec.ts
@@ -137,13 +137,13 @@ test.describe.serial('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }
   });
   test.describe
   .serial('PVC lifecycle test', () => {
-    test('CCreate a pod bound to a PVC and verify its stopped', async({page}) => {
+    test('Create a pod bound to a PVC and verify its in Unknown state', async({page}) => {
       await applyYamlFileToCluster(page, PVC_POD_YAML_PATH, KUBERNETES_RUNTIME);
       await checkKubernetesResourceState(
         page,
         KubernetesResources.Pods,
         PVC_POD_NAME,
-        KubernetesResourceState.Stopped,
+        KubernetesResourceState.Unknown,
       );
     }) 
     test('Create a PVC and verify the bound pod is in running state', async ({ page }) => {

--- a/tests/playwright/src/spec/kubernetes.spec.ts
+++ b/tests/playwright/src/spec/kubernetes.spec.ts
@@ -19,7 +19,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { checkDeploymentReplicasInfo, checkKubernetesResourceState, createKubernetesResource, deleteCluster, deleteKubernetesResource, editDeploymentYamlFile, ensureCliInstalled, expect as playExpect, isLinux, KubernetesResources, KubernetesResourceState, minikubeExtension,PlayYamlRuntime,test} from '@podman-desktop/tests-playwright';
+import { checkDeploymentReplicasInfo, checkKubernetesResourceState, createKubernetesResource, deleteCluster, deleteKubernetesResource, editDeploymentYamlFile, ensureCliInstalled, expect as playExpect, isLinux, KubernetesResources, KubernetesResourceState, minikubeExtension,PlayYamlRuntime,test, applyYamlFileToCluster, deletePod} from '@podman-desktop/tests-playwright';
 
 import { createMinikubeCluster} from '../utility/operations';
 
@@ -29,6 +29,11 @@ const CLUSTER_CREATION_TIMEOUT: number = 300_000;
 const KUBERNETES_CONTEXT = 'minikube';
 const KUBERNETES_NAMESPACE = 'default';
 const DEPLOYMENT_NAME = 'test-deployment-resource';
+const PVC_NAME = 'test-pvc-resource';
+const PVC_POD_NAME = 'test-pod-pvcs';
+const CONFIGMAP_NAME = 'test-configmap-resource';
+const SECRET_NAME = 'test-secret-resource';
+const SECRET_POD_NAME = 'test-pod-configmaps-secrets';
 const KUBERNETES_RUNTIME = {
   runtime: PlayYamlRuntime.Kubernetes,
   kubernetesContext: KUBERNETES_CONTEXT,
@@ -38,6 +43,11 @@ const KUBERNETES_RUNTIME = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEPLOYMENT_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${DEPLOYMENT_NAME}.yaml`);
+const PVC_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${PVC_NAME}.yaml`);
+const PVC_POD_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${PVC_POD_NAME}.yaml`);
+const CONFIGMAP_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${CONFIGMAP_NAME}.yaml`);
+const SECRET_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${SECRET_NAME}.yaml`);
+const SECRET_POD_YAML_PATH = path.resolve(__dirname, '..', '..', 'resources', 'kubernetes', `${SECRET_POD_NAME}.yaml`);
 
 const EXTENSION_IMAGE: string = process.env.EXTENSION_IMAGE ?? 'ghcr.io/podman-desktop/podman-desktop-extension-minikube:nightly';
 
@@ -123,6 +133,73 @@ test.describe.serial('Kubernetes resources End-to-End test', { tag: '@k8s_e2e' }
     });
     test('Delete the Kubernetes deployment resource', async ({ page }) => {
       await deleteKubernetesResource(page, KubernetesResources.Deployments, DEPLOYMENT_NAME);
+    });
+  });
+  test.describe
+  .serial('PVC lifecycle test', () => {
+    test('Create a new PVC resource', async ({ page }) => {
+      await createKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME, PVC_YAML_PATH, KUBERNETES_RUNTIME);
+      await checkKubernetesResourceState(page, KubernetesResources.PVCs, PVC_NAME, KubernetesResourceState.Stopped);
+    });
+    test('Bind the PVC to a pod', async ({ page }) => {
+      await applyYamlFileToCluster(page, PVC_POD_YAML_PATH, KUBERNETES_RUNTIME);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Pods,
+        PVC_POD_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Delete the PVC resource', async ({ page }) => {
+      await deleteKubernetesResource(page, KubernetesResources.Pods, PVC_POD_NAME);
+      await deleteKubernetesResource(page, KubernetesResources.PVCs, PVC_NAME);
+    });
+  });
+test.describe
+  .serial('ConfigMaps and Secrets lifecycle test', () => {
+    test('Create ConfigMap resource', async ({ page }) => {
+      await createKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        CONFIGMAP_NAME,
+        CONFIGMAP_YAML_PATH,
+        KUBERNETES_RUNTIME,
+      );
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        CONFIGMAP_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Create Secret resource', async ({ page }) => {
+      await createKubernetesResource(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        SECRET_NAME,
+        SECRET_YAML_PATH,
+        KUBERNETES_RUNTIME,
+      );
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.ConfigMapsSecrets,
+        SECRET_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Can load config and secrets via env. var in pod', async ({ page }) => {
+      await applyYamlFileToCluster(page, SECRET_POD_YAML_PATH, KUBERNETES_RUNTIME);
+      await checkKubernetesResourceState(
+        page,
+        KubernetesResources.Pods,
+        SECRET_POD_NAME,
+        KubernetesResourceState.Running,
+      );
+    });
+    test('Delete the ConfigMap and Secret resources', async ({ page }) => {
+      await deletePod(page, SECRET_POD_NAME);
+      await deleteKubernetesResource(page, KubernetesResources.ConfigMapsSecrets, SECRET_NAME);
+      await deleteKubernetesResource(page, KubernetesResources.ConfigMapsSecrets, CONFIGMAP_NAME);
     });
   });
 });


### PR DESCRIPTION
What does this PR do?
Adds e2e tests for configmap, secret and pvc k8s resources.

Closes: https://github.com/podman-desktop/extension-minikube/issues/472 https://github.com/podman-desktop/extension-minikube/issues/470