### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "minikube",
+  "repository": "https://github.com/podman-desktop/extension-minikube",
+  "homepage": "https://github.com/podman-desktop/extension-minikube#readme",
   "displayName": "Minikube",
   "description": "Integration for minikube: a tool that makes it easy to run Kubernetes locally",
   "version": "0.5.0-next",


### PR DESCRIPTION
### What does this PR do?

Add missing `repository` and `homepage` fields in the extension `package.json`.

### Screenshot / video of UI

N/A (metadata-only change)

### What issues does this PR fix or reference?

Closes #961

### How to test this PR?

1. Open `package.json`.
2. Verify both `repository` and `homepage` are present and point to this GitHub repository.
3. Confirm no other files changed.
